### PR TITLE
Simplify and improve auru

### DIFF
--- a/aura.sh
+++ b/aura.sh
@@ -75,6 +75,14 @@ auru() {
     esac
 }
 
+self_update() {
+    git clone https://github.com/jtexeira/tiny-aura.git /tmp/tiny-aura
+    cd /tmp/tiny-aura || return 1
+    sudo make
+    cd || return 1
+    rm -rf /tmp/tiny-aura
+}
+
 main() {
     case $1 in
         -e)
@@ -104,6 +112,9 @@ main() {
             ;;
         -S+(y)u)
             auru "${@:2}"
+            ;;
+        update)
+            self_update
             ;;
         *)
             main -S "$@"

--- a/aura.sh
+++ b/aura.sh
@@ -84,7 +84,18 @@ main() {
             ;;
         -S)
             shift
-            aur "$@"
+            other_args=()
+            pkgs=()
+            while [ "$#" -gt 0 ]; do
+                case "$1" in
+                    -*) other_args+=("$1") ;;
+                    *) pkgs+=("$1") ;;
+                esac
+                shift
+            done
+            for p in "${pkgs[@]}"; do
+                aur "$p" "${other_args[@]}"
+            done
             ;;
         -Ss)
             aurs "$2"


### PR DESCRIPTION
- `pacman -Qm` shows packages installed without `pacman` thus there is no need to
filter through all the other packages in the system.

Also auru não accepts arguments too, just like aur so
```
aura -Syu spotify --skippgpcheck
```
works.

- Fixed a bug in `aur` at the cost of it now only installing one package at a
time. But maintaining the multiple package setup for the overall script

- Added a self update function